### PR TITLE
refact/replace dynamic bootstrap loading with subprocess loading

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,7 +4,7 @@ __pycache__/
 *$py.class
 .DS_Store
 pagopa512x512.icns
-as-dynapp.zip
+as-dynapp.tar.gz
 
 # C extensions
 *.so
@@ -34,7 +34,6 @@ MANIFEST
 #  Usually these files are written by a python script from a template
 #  before PyInstaller builds the exe, so as to inject date/other infos into it.
 *.manifest
-*.spec
 
 # Installer logs
 pip-log.txt

--- a/as-dynapp/app.spec
+++ b/as-dynapp/app.spec
@@ -1,0 +1,59 @@
+# -*- mode: python ; coding: utf-8 -*-
+
+
+a = Analysis(
+    ['app/main.py'],
+    pathex=[],
+    binaries=[],
+    datas=[('app/pagopa.png', '.')],
+    hiddenimports=[],
+    hookspath=[],
+    hooksconfig={},
+    runtime_hooks=[],
+    excludes=[],
+    noarchive=False,
+    optimize=0,
+)
+pyz = PYZ(a.pure)
+
+exe = EXE(
+    pyz,
+    a.scripts,
+    [],
+    exclude_binaries=True,
+    name='AS-DynApp',
+    debug=False,
+    bootloader_ignore_signals=False,
+    strip=False,
+    upx=True,
+    console=False,
+    disable_windowed_traceback=False,
+    argv_emulation=False,
+    target_arch=None,
+    codesign_identity=None,
+    entitlements_file=None,
+    icon=['pagopa512x512.icns'],
+)
+coll = COLLECT(
+    exe,
+    a.binaries,
+    a.datas,
+    strip=False,
+    upx=True,
+    upx_exclude=[],
+    name='AS-DynApp',
+)
+app = BUNDLE(
+    coll,
+    name='AS-DynApp.app',
+    icon='pagopa512x512.icns',
+    bundle_identifier='it.pagopa.assistenza.as-dynapp',
+    info_plist={
+        'CFBundleName': 'AS-DynApp',
+        'CFBundleDisplayName': 'AS-DynApp',
+        'CFBundleGetInfoString': 'AS-DynApp 2.1.0045',
+        'CFBundleShortVersionString': '2.1.0045',
+        'CFBundleVersion': '2.1.0045',
+        'CFBundleIdentifier': 'it.pagopa.assistenza.as-dynapp',
+    }
+)

--- a/as-dynapp/app/constants.py
+++ b/as-dynapp/app/constants.py
@@ -3,8 +3,9 @@
 import os
 from datetime import datetime, timedelta
 
-APP_NAME = "SideConv2csv"
-APP_VERSION = "(v2.1 build 0045)"
+APP_NAME = "AS-DynApp"
+BUILD_NUMBER = "0045"
+APP_VERSION = "2.1"
 EMPTY = "N/A"
 READY = "--------------------------\nREADY"
 DONE_MESSAGE = f'\nESTRAZIONE COMPLETATA! Il file CSV è stato salvato nella cartella "ZD_script_reports" del tuo desktop.\n{READY}\n'

--- a/as-dynapp/app/main.py
+++ b/as-dynapp/app/main.py
@@ -7,6 +7,7 @@ from tkinter import PhotoImage, messagebox, ttk
 from constants import (
     APP_NAME,
     APP_VERSION,
+    BUILD_NUMBER,
     LABELS_GROUP,
     LABELS_TAG,
     LABELS_TIMERANGE,
@@ -23,8 +24,7 @@ from ZDExtractor import ZDExtractor
 
 
 class App:
-    def __init__(self, project_base_path):
-        self.project_base_path = project_base_path
+    def __init__(self):
         self.root = tk.Tk()
 
         # Drop-down menus
@@ -118,9 +118,11 @@ class App:
         self.root.after(1000, self.sync_output)  # next check in 1s
 
     def start(self):
+        base_path = os.path.dirname(os.path.abspath(__file__))
+
         # Setup root window
-        self.root.title(f"{APP_NAME} {APP_VERSION}")
-        icon_path = os.path.join(self.project_base_path, "pagopa.png")
+        self.root.title(f"{APP_NAME} {APP_VERSION} build {BUILD_NUMBER}")
+        icon_path = os.path.join(base_path, "pagopa.png")
         icon = PhotoImage(file=icon_path)
         self.root.iconphoto(True, icon)
         self.root.resizable(False, False)
@@ -145,7 +147,7 @@ class App:
         # Title
         title = tk.Label(
             main_frame,
-            text="ZD Estrattore Conversazioni Laterali",
+            text="ZD Estrazione Contatti Conversazioni Laterali",
             font=("Helvetica", 20, "bold"),
         )
         title.pack()
@@ -153,7 +155,7 @@ class App:
         # Subtitle
         subtitle = tk.Label(
             main_frame,
-            text="Generazione file CSV delle conversazioni laterali email, secondo i filtri impostati",
+            text="Generazione file CSV dei contatti email risultanti dai filtri impostati",
             font=("Helvetica", 12),
         )
         subtitle.pack()
@@ -195,7 +197,7 @@ class App:
 
         # ----- Retrieve/Set credentials for Zendesk -----
         cm = CredentialManager()
-        print(f"{APP_NAME} {APP_VERSION}\n")
+        print(f"{APP_NAME} {APP_VERSION} build {BUILD_NUMBER}\n")
         try:
             creds = cm.get_credentials()
             bearer = creds["password"]
@@ -222,11 +224,10 @@ class App:
         self.root.mainloop()
 
 
-def main(project_base_path):
-    app = App(project_base_path)
+def main():
+    app = App()
     app.start()
 
 
 if __name__ == "__main__":
-    # this is just for running without an external launcher
-    main(os.path.dirname(os.path.realpath(__file__)))
+    main()

--- a/as-dynapp/build_all.sh
+++ b/as-dynapp/build_all.sh
@@ -1,0 +1,7 @@
+rm -rf build dist
+
+pyinstaller launcher.spec
+pyinstaller app.spec
+
+cd dist
+tar cvfz AS-DynApp.tar.gz AS-DynApp.app

--- a/as-dynapp/build_launcher.sh
+++ b/as-dynapp/build_launcher.sh
@@ -1,0 +1,2 @@
+rm -rf build dist/as-launcher
+pyinstaller launcher.spec

--- a/as-dynapp/build_zip.sh
+++ b/as-dynapp/build_zip.sh
@@ -1,2 +1,0 @@
-rm -rf as-dynapp.zip app/__pycache__/
-zip -r as-dynapp.zip app/

--- a/as-dynapp/launcher.py
+++ b/as-dynapp/launcher.py
@@ -1,50 +1,42 @@
-import importlib.util
 import io
 import os
 import shutil
-import sys
+import subprocess
+import tarfile
 import tempfile
-import zipfile
 
 import requests
 
-APP_URL = "https://github.com/pagopa/assistenza-zendesk-maintenance/releases/latest/download/as-dynapp.zip"
-APP_ENTRY = "main.py"
-APP_DIR_NAME = "app"
+APP_NAME = "AS-DynApp"
+APP_URL = f"https://github.com/pagopa/assistenza-zendesk-maintenance/releases/latest/download/{APP_NAME}.tar.gz"
 
 
-def download_and_extract_zip(url, extract_to):
-    print("Downloading app...")
+def download_and_extract(url, extract_to):
+    print("Preparing app...")
     response = requests.get(url)
     response.raise_for_status()
+    with tarfile.open(fileobj=io.BytesIO(response.content), mode="r:gz") as tar_ref:
+        tar_ref.extractall(path=extract_to)
 
-    with zipfile.ZipFile(io.BytesIO(response.content)) as zip_ref:
-        zip_ref.extractall(extract_to)
-    print("App successfully extracted.")
+    print("App is ready.")
 
 
-def run_app(app_dir):
-    project_path = os.path.join(app_dir, APP_DIR_NAME)
-    main_path = os.path.join(project_path, APP_ENTRY)
-    if project_path not in sys.path:
-        sys.path.insert(0, project_path)
-
-    spec = importlib.util.spec_from_file_location("main", main_path)
-    module = importlib.util.module_from_spec(spec)
-    sys.modules["main"] = module
-    spec.loader.exec_module(module)
-
-    if hasattr(module, "main"):
-        module.main(project_path)
+def run_app(app_path):
+    try:
+        print("[INFO] Starting app...")
+        subprocess.run([app_path], check=True)
+    except subprocess.CalledProcessError as e:
+        print(f"[ERROR] {e}")
 
 
 def main():
-    temp_dir = tempfile.mkdtemp(prefix="remote_app_")
+    temp_p = tempfile.mkdtemp(prefix="remote_app_")
     try:
-        download_and_extract_zip(APP_URL, temp_dir)
-        run_app(temp_dir)
+        download_and_extract(APP_URL, temp_p)
+        bin_p = os.path.join(temp_p, f"{APP_NAME}.app", "Contents", "MacOS", APP_NAME)
+        run_app(bin_p)
     finally:
-        shutil.rmtree(temp_dir, ignore_errors=True)
+        shutil.rmtree(temp_p, ignore_errors=True)
 
 
 if __name__ == "__main__":

--- a/as-dynapp/launcher.spec
+++ b/as-dynapp/launcher.spec
@@ -1,0 +1,38 @@
+# -*- mode: python ; coding: utf-8 -*-
+
+
+a = Analysis(
+    ['launcher.py'],
+    pathex=[],
+    binaries=[],
+    datas=[],
+    hiddenimports=[],
+    hookspath=[],
+    hooksconfig={},
+    runtime_hooks=[],
+    excludes=[],
+    noarchive=False,
+    optimize=0,
+)
+pyz = PYZ(a.pure)
+
+exe = EXE(
+    pyz,
+    a.scripts,
+    a.binaries,
+    a.datas,
+    [],
+    name='as-launcher',
+    debug=False,
+    bootloader_ignore_signals=False,
+    strip=False,
+    upx=True,
+    upx_exclude=[],
+    runtime_tmpdir=None,
+    console=True,
+    disable_windowed_traceback=False,
+    argv_emulation=False,
+    target_arch=None,
+    codesign_identity=None,
+    entitlements_file=None,
+)


### PR DESCRIPTION
The initial implementation was based on dynamic bootstrap loading which unfortunately has a problem: all the App external dependencies (eg. tkinter package and its subpackages, keyring, dotenv, etc.) must be injected in the Launcher. The reason is that both Launcher and App run in the same process. That means no full separation between Launcher and App, as you need to rebuild and redistribute the Launcher each time you add a new (external) dependency...

Based on that, this commit has totally replaced above mechanism with an alternative way to address our separation goal: Launcher and App run in separate processes (main->subprocess). Both launcher and app have their own specific Pyinstaller statically linked binary, so you can distribute the launcher just one time, regardless of any future dependency you may add to the App.